### PR TITLE
Add key-mapping customization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ to specify a diffrent filetype use the Pipe2 command `:Pipe2 redis`, `:Pipe2 mon
 
 evaluate an empty line will clear the context
 
+## key mappings
+By default, pipe2eval maps `<Space>` in Visual mode with:
+
+```vim
+  vmap <buffer> <Space> ':![pipe2eval dir]/plugin/pipe2eval.sh text<CR><CR>'
+```
+
+This mapping can be customized by setting `g:pipe2eval_map_key`. For example:
+
+```vim
+  let g:pipe2eval_map_key = '<Leader>p2e'
+```
+
 ### specify a mysql connection
 
 ```sql

--- a/doc/pipe2eval.txt
+++ b/doc/pipe2eval.txt
@@ -1,0 +1,42 @@
+*pipe2eval.txt*  simple REPL inside vim
+Author:  zweifisch <https://github.com/zweifisch>
+License: Same terms as Vim itself (see |license|)
+
+================================================================================
+INTRODUCTION                                                         *pipe2eval*
+
+Supports: python, php, coffee, mysql, mongodb, redis, sh, go, javascript, ruby,
+elixir ...
+
+================================================================================
+USAGE                                                          *pipe2eval-usage*
+
+Press V<Space> to evaluate current line, vip<space> to evaluate a paragraph.
+
+Evaluate an empty line to clear the buffer's context.
+
+pipe2eval will set the evaluation language based on each buffer's |filetype|.
+
+--------------------------------------------------------------------------------
+                                                              *pipe2eval-:Pipe2*
+:Pipe2 [filetype]       To specify a different filetype
+                        Examples:
+                          :Pipe2 redis
+                          :Pipe2 mongo
+
+--------------------------------------------------------------------------------
+KEY MAPPINGS                                            *pipe2eval-key-mappings*
+By default, pipe2eval maps <Space> in |Visual| mode with:
+  vmap <buffer> <Space> ':![pipe2eval dir]/plugin/pipe2eval.sh text<CR><CR>'
+This mapping can be customized by setting the |g:pipe2eval_map_key|
+
+g:pipe2eval_map_key                                          *pipe2eval-map_key*
+                        Change the key to be mapped by pipe2eval
+                        Example:
+                          let g:pipe2eval_map_key = '<Leader>p2e'
+
+================================================================================
+ABOUT                                                          *pipe2eval-about*
+
+Grab the latest version or report a bug on GitHub:
+http://github.com/zweifisch/pipe2eval

--- a/plugin/pipe2eval.vim
+++ b/plugin/pipe2eval.vim
@@ -1,9 +1,10 @@
 com! -nargs=+ Pipe2 call Pipe2eval(<f-args>)
 
-let g:pipe2eval = expand('<sfile>:p:h') . '/pipe2eval.sh'
+let s:map_key_default = "<Space>"
 
 function! Pipe2eval(lang)
-	execute "vm <buffer> <space> :!". g:pipe2eval ." ". a:lang . "<CR><CR>"
+  let l:map_key = exists('g:pipe2eval_map_key') ? g:pipe2eval_map_key : s:map_key_default
+	execute "vm <buffer> ". l:map_key ." :!". g:pipe2eval ." ". a:lang . "<CR><CR>"
 endfunction
 
 au FileType * call Pipe2eval(&filetype)


### PR DESCRIPTION
I found that I constantly hit `<Space>` by accident when marking visual
selections, which I do frequently. I tried to map the pipe2eval key to
something else but found it was impossible.
- Add a default map key to continue current behaviour
- Add a global variable to hold user-defined custom key for mapping
  - g:pipe2eval_map_key
- Modify plugin/pipe2eval.vim to accept both custom key and default
- Update the README.md to relect the change

I found that there was no `:help pipe2eval`(!).
- Add doc/pipe2eval.txt
